### PR TITLE
Detailed exception when wrong variable type

### DIFF
--- a/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/variable/VariableParsingService.java
+++ b/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/variable/VariableParsingService.java
@@ -26,7 +26,12 @@ public class VariableParsingService {
 
         if(variableDefinition.getType()!=null) {
             VariableType type = variableTypeMap.get(variableDefinition.getType());
-
+            if(type==null){
+				throw new ActivitiException(
+						"Unknown type '" + variableDefinition.getType() + "' of variable with identifier '"
+								+ variableDefinition.getId() + "' and name '" + variableDefinition.getName()
+								+ "'. Available types: " + String.join(", ", variableTypeMap.keySet()));
+            }
             return type.parseFromValue(variableDefinition.getValue());
         }
 


### PR DESCRIPTION
Throw detailed exception about wrong variable type in VariableParsingService. NPE was thrown when variable type was incorrect.